### PR TITLE
Allow multiple platforms

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,1 +1,46 @@
 """TapHome integration."""
+
+from .taphome_sdk import *
+from homeassistant.helpers.discovery import async_load_platform
+import voluptuous as voluptuous
+import homeassistant.helpers.config_validation as config_validation
+
+from homeassistant.const import CONF_TOKEN, CONF_LIGHTS
+
+DOMAIN = "taphome"
+TAPHOME = f"{DOMAIN}_TapHome"
+
+CONFIG_SCHEMA = voluptuous.Schema(
+    {
+        DOMAIN: voluptuous.Schema(
+            voluptuous.All(
+                config_validation.has_at_least_one_key(CONF_LIGHTS),
+                {
+                    voluptuous.Required(CONF_TOKEN): config_validation.string,
+                    voluptuous.Optional(CONF_LIGHTS, default=[]): config_validation.ensure_list,
+                },
+            )
+        )
+    },
+    extra=voluptuous.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass, config):
+
+    token = config[DOMAIN][CONF_TOKEN]
+    lights = config[DOMAIN][CONF_LIGHTS]
+
+    tapHomeHttpClientFactory = TapHomeHttpClientFactory()
+    tapHomeHttpClient = tapHomeHttpClientFactory.create(token)
+    tapHome = TapHome(tapHomeHttpClient)
+    hass.data[TAPHOME] = tapHome
+
+    if lights:
+        hass.async_create_task(
+            async_load_platform(
+                hass, "light", DOMAIN, lights, config
+            )
+        )
+
+    return True

--- a/light.py
+++ b/light.py
@@ -2,32 +2,15 @@
 from .taphome_sdk import *
 
 import logging
-import voluptuous
-import homeassistant.helpers.config_validation as config_validation
+from homeassistant.components.light import LightEntity
 
-# Import the device class from the component that you want to support
-from homeassistant.components.light import PLATFORM_SCHEMA, LightEntity
-from homeassistant.const import CONF_TOKEN, CONF_LIGHTS
+from . import TAPHOME
 
 _LOGGER = logging.getLogger(__name__)
 
-# Validation of the user's configuration
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        voluptuous.Required(CONF_TOKEN): config_validation.string,
-        voluptuous.Required(CONF_LIGHTS): config_validation.ensure_list,
-    }
-)
 
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    token = config[CONF_TOKEN]
-    lightIds = config[CONF_LIGHTS]
-
-    tapHomeHttpClientFactory = TapHomeHttpClientFactory()
-    tapHomeHttpClient = tapHomeHttpClientFactory.create(token)
-    tapHome = TapHome(tapHomeHttpClient)
-
+async def async_setup_platform(hass, config, async_add_entities, lightIds):
+    tapHome = hass.data[TAPHOME]
     devices = (await tapHome.async_discovery_devices())["devices"]
 
     lights = []
@@ -74,15 +57,10 @@ class SimpleTapHomeLight(LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn device on."""
-        print(f"Turn {self._name} on.")
-        print(kwargs)
         result = await self._tapHome.async_turn_on_light(self._deviceId)
         self._is_on = result == TapHome.ValueChangeResult.CHANGED
-        print(f"Turn {self._name} on.")
 
     async def async_turn_off(self):
         """Turn device off."""
-        print(f"Turn {self._name} off.")
         result = await self._tapHome.async_turn_off_light(self._deviceId)
         self._is_on = not result == TapHome.ValueChangeResult.CHANGED
-        print(f"Turn {self._name} on.")

--- a/readme.md
+++ b/readme.md
@@ -12,12 +12,11 @@ Copy this folder to `<config_dir>/custom_components/taphome/`.
 Add the following entry in your `configuration.yaml`:
 
 ```yaml
-light:
-  - platform: taphome
-    token: 00000000-0000-0000-0000-000000000000
-    lights:
-      - 1
-      - 7
+taphome:
+  token: 00000000-0000-0000-0000-000000000000
+  lights:
+    - 1
+    - 7
 ```
 
 You have to specify your token and id of your lights. For more information visit https://taphome.com/en/support/601227274

--- a/taphome_sdk.py
+++ b/taphome_sdk.py
@@ -93,5 +93,4 @@ class TapHome:
             result = json["valuesChanged"][0]["result"]
             return TapHome.ValueChangeResult.from_string(result)
         except:
-            print(json)
             return TapHome.ValueChangeResult.FAILED


### PR DESCRIPTION
We need to work with more than one platform. To allow it I had to change initialization and that has a impact to config.yaml
[Integration with Multiple Platforms](https://developers.home-assistant.io/docs/creating_component_generic_discovery#loading-platforms-when-configured-via-configurationyaml)