### PR TITLE
coordinator: fixed non-working update of taphome data in case the tahome core is reset

### DIFF
--- a/coordinator.py
+++ b/coordinator.py
@@ -149,6 +149,11 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         else:
             for device_id in self._devices:
                 self._devices[device_id].taphome_state = None
+
+            # clear the last update timestamp so the device values get correctly updates next time the connection is re-established
+            # (when Taphome core is reset, the timestamp calculation gets reset as well, which may block further updates of device values until
+            # the new timestamp reaches the previous value)
+            self.last_update_devices_values_timestamp = 0;
             raise UpdateFailed()
 
     def get_device_data(


### PR DESCRIPTION
The problem was caused by the fact that timestamps received from taphome core after reset are again counted from zero,
which basically blocks the update of the ui due to the statement evaluation:

if (
    self.last_update_devices_values_timestamp
    < all_devices_values["timestamp"]
):

Without this simple fix this would require a manual restart of the whole HA to be able to get the Taphome working again.

Signed-off-by: Stanislav Ruzani <stanislav.ruzani@gmail.com>