### PR TITLE
sensor: removed duplicated specification of TapHomePulseCounterLastMasuredFrequencySensorType() in supported_sensor_types

### DIFF
--- a/sensor.py
+++ b/sensor.py
@@ -337,7 +337,6 @@ class TapHomeSensorCreateRequest(TapHomeDataUpdateCoordinatorObject[TapHomeState
                 TapHomePulseCounterTotalImpulseCountSensorType(),
                 TapHomePulseCounterCurrentHourImpulseCountSensorType(),
                 TapHomePulseCounterLastMeasuredFrequencySensorType(),
-                TapHomePulseCounterLastMeasuredFrequencySensorType(),
                 TapHomeVariableType(),
             ]
 


### PR DESCRIPTION
This could cause exception during initialization of integration due to adding the same entity twice,
for example:

ERROR (MainThread) [homeassistant.components.sensor] Platform taphome does not generate unique IDs. ID taphome.sensor.<xxx> already exists - ignoring sensor.<xxx>

Signed-off-by: Stanislav Ruzani <stanislav.ruzani@gmail.com>