### PR TITLE
TapHome also adjusts the tilt of the blind when changing the position…

### DIFF
--- a/cover.py
+++ b/cover.py
@@ -122,10 +122,12 @@ class TapHomeCover(TapHomeEntity[CoverState], CoverEntity):
         if ATTR_POSITION in kwargs:
             ha_position = kwargs.get(ATTR_POSITION)
             taphome_position = 1 - self.convert_ha_percentage_to_taphome(ha_position)
+            taphome_tilt = 1 - self.convert_ha_percentage_to_taphome(self.current_cover_tilt_position)
 
+            # TapHome also adjusts the tilt of the blind when changing the position. This is not a demanding behavior for me. So I use the existing tilt to preserve the value
             async with UpdateTapHomeState(self) as state:
                 await self.cover_service.async_set_level(
-                    self.taphome_device, taphome_position
+                    self.taphome_device, taphome_position, taphome_tilt
                 )
                 state.blinds_level = taphome_position
 

--- a/taphome_sdk/cover_service.py
+++ b/taphome_sdk/cover_service.py
@@ -33,12 +33,15 @@ class CoverService:
             _LOGGER.error(f"TapHome async_get_state for {device.id} failed")
             return None
 
-    def async_set_level(self, device: Device, position) -> None:
+    def async_set_level(self, device: Device, position, tilt=None) -> None:
         values = [
             self.taphome_api_service.create_device_value(
                 ValueType.BlindsLevel, position
             )
         ]
+
+        if tilt is not None:
+            values.append(self.taphome_api_service.create_device_value(ValueType.BlindsSlope, tilt))
 
         return self.taphome_api_service.async_set_device_values(device.id, values)
 


### PR DESCRIPTION
…. This is not a demanding behavior for me. So I use the existing tilt to preserve the value