### PR TITLE
Release 2024.8.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2024.8.0
+- Introduce `close_threshold` for covers
+
 ## 2024.5.0
 - New Valve entity type.
 - New Humidifier entity type.

--- a/cover.py
+++ b/cover.py
@@ -24,10 +24,15 @@ class CoverConfigEntry(TapHomeConfigEntry):
     def __init__(self, device_config: dict):
         super().__init__(device_config)
         self._device_class = self.get_optional("device_class", None)
+        self._close_threshold = self.get_optional("close_threshold", 100)
 
     @property
     def device_class(self):
         return self._device_class
+
+    @property
+    def close_threshold(self):
+        return self._close_threshold
 
 
 class TapHomeCover(TapHomeEntity[CoverState], CoverEntity):
@@ -37,7 +42,7 @@ class TapHomeCover(TapHomeEntity[CoverState], CoverEntity):
         self,
         hass: HomeAssistant,
         core_config: TapHomeCoreConfigEntry,
-        config_entry: TapHomeConfigEntry,
+        config_entry: CoverConfigEntry,
         coordinator: TapHomeDataUpdateCoordinator,
         cover_service: CoverService,
     ):
@@ -46,6 +51,7 @@ class TapHomeCover(TapHomeEntity[CoverState], CoverEntity):
         )
         self.cover_service = cover_service
         self._device_class = config_entry.device_class
+        self._close_threshold = config_entry.close_threshold
         self._supported_features = None
 
     @property
@@ -87,9 +93,9 @@ class TapHomeCover(TapHomeEntity[CoverState], CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if self.current_cover_position is None:
+        if self.taphome_state.blinds_level is None:
             return None
-        return self.current_cover_position == 0
+        return self.taphome_state.blinds_level >= self._close_threshold / 100
 
     @property
     def current_cover_position(self):

--- a/docs/config-generator/dist/script.js
+++ b/docs/config-generator/dist/script.js
@@ -116,8 +116,11 @@ var TapHomeDevice = /** @class */ (function () {
             if (!this.isSelected) {
                 return "";
             }
-            else if (this.entityType === HomeAssistantEntityType.switch || this.entityType === HomeAssistantEntityType.cover) {
+            else if (this.entityType === HomeAssistantEntityType.switch) {
                 return this.deviceClassConfig;
+            }
+            else if (this.entityType === HomeAssistantEntityType.cover) {
+                return this.coverConfig;
             }
             else if (this.entityType === HomeAssistantEntityType.climate) {
                 return this.climateConfig;
@@ -137,6 +140,23 @@ var TapHomeDevice = /** @class */ (function () {
         get: function () {
             if (this.deviceClass) {
                 var config = "\n        - id: " + this.deviceId + "\n          device_class: " + this.deviceClass;
+                return config;
+            }
+            return this.idConfig;
+        },
+        enumerable: false,
+        configurable: true
+    });
+    Object.defineProperty(TapHomeDevice.prototype, "coverConfig", {
+        get: function () {
+            if (this.deviceClass || this.coverCloseThreshold) {
+                var config = "\n        - id: " + this.deviceId;
+                if (this.deviceClass) {
+                    config += "\n          device_class: " + this.deviceClass;
+                }
+                if (this.coverCloseThreshold) {
+                    config += "\n          close_threshold: " + this.coverCloseThreshold;
+                }
                 return config;
             }
             return this.idConfig;

--- a/docs/config-generator/index.html
+++ b/docs/config-generator/index.html
@@ -322,6 +322,25 @@
                                                     </div>
                                                 </div>
                                             </div>
+                                            <div v-if="device.entityType === HomeAssistantEntityType.cover">
+                                                <div class="row mt-3">
+                                                    <label
+                                                        v-bind:for="'close_threshold' + taphomeCore.token + device.deviceId"
+                                                        class="col-sm-5 col-form-label">
+                                                        Close threshold
+                                                    </label>
+                                                    <div class="col-sm-7">
+                                                        <input
+                                                            type="number" min="0" max="100" placeholder="100"
+                                                            v-bind:id="'close_threshold' + taphomeCore.token + device.deviceId"
+                                                            class="form-control" v-model="device.coverCloseThreshold"" />
+                                                            <small class="form-text">
+                                                                Represents the threshold level at which the cover is considered fully closed.
+                                                                For instance, this is appropriate for roller shutter when shaded 80%.
+                                                            </small>
+                                                    </div>
+                                                </div>
+                                            </div>
                                             <div v-if="device.entityType === HomeAssistantEntityType.climate">
                                                 <div class="row mt-3">
                                                     <label

--- a/docs/config-generator/package-lock.json
+++ b/docs/config-generator/package-lock.json
@@ -1,14 +1,29 @@
 {
   "name": "taphome-homeassistant-config",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "typescript": {
+  "packages": {
+    "": {
+      "name": "taphome-homeassistant-config",
+      "version": "0.1.0",
+      "license": "GPL v3 with Commons Clause",
+      "devDependencies": {
+        "typescript": "^4.2.4"
+      }
+    },
+    "node_modules/typescript": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
       "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
-      "dev": true
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     }
   }
 }

--- a/docs/config-generator/src/script.ts
+++ b/docs/config-generator/src/script.ts
@@ -80,6 +80,8 @@ class TapHomeDevice {
     buttonDoublePressAction: boolean;
     buttonTripplePressAction: boolean;
 
+    coverCloseThreshold: number;
+    
     climateMinTemperature: number;
     climateMaxTemperature: number;
     climateHeatingSwitchIdingCoolingModeId: number;
@@ -104,8 +106,10 @@ class TapHomeDevice {
     get config() {
         if (!this.isSelected) {
             return "";
-        } else if (this.entityType === HomeAssistantEntityType.switch || this.entityType === HomeAssistantEntityType.cover) {
+        } else if (this.entityType === HomeAssistantEntityType.switch) {
             return this.deviceClassConfig;
+        } else if (this.entityType === HomeAssistantEntityType.cover) {
+            return this.coverConfig;
         } else if (this.entityType === HomeAssistantEntityType.climate) {
             return this.climateConfig;
         } else if (this.entityType === HomeAssistantEntityType.sensor) {
@@ -119,6 +123,21 @@ class TapHomeDevice {
     private get deviceClassConfig() {
         if (this.deviceClass) {
             let config = `\n        - id: ${this.deviceId}\n          device_class: ${this.deviceClass}`;
+            return config;
+        }
+        return this.idConfig;
+    }
+
+    private get coverConfig() {
+        if (this.deviceClass || this.coverCloseThreshold) {
+            let config = `\n        - id: ${this.deviceId}`;
+            if (this.deviceClass) {
+                config += `\n          device_class: ${this.deviceClass}`;
+            }
+            if (this.coverCloseThreshold) {
+                config += `\n          close_threshold: ${this.coverCloseThreshold}`;
+            }
+
             return config;
         }
         return this.idConfig;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "taphome",
   "name": "TapHome",
-  "version": "2024.5.0",
+  "version": "2024.8.0",
   "iot_class": "local_push",
   "documentation": "https://github.com/martindybal/taphome-homeassistant",
   "issue_tracker": "https://github.com/martindybal/taphome-homeassistant/issues",


### PR DESCRIPTION
- Introduced a new configuration variable for cover `close_threshold`.
  - This represents the threshold level at which the cover is considered fully closed.
  - For instance, this is appropriate for roller shutter when shaded 80%.