### PR TITLE
Reducing communication with TapHome Core

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import typing
 
+from aiohttp.web import Request
 from async_timeout import timeout
 import voluptuous
 
@@ -155,8 +156,8 @@ CONFIG_SCHEMA = voluptuous.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigEntry) -> bool:
     if CONF_LANGUAGE in config[TAPHOME_PLATFORM]:
-        _LOGGER.warning(
-            "TapHome language setting is not supported any more. You can renema entities as you wish. This options'll be removed in future, please remove it from your config"
+        _LOGGER.error(
+            "TapHome language setting is not supported any more. You can rename entities as you wish. This options'll be removed in future, please remove it from your config"
         )
 
     if len(config[TAPHOME_PLATFORM][CONF_CORES]) > 1:
@@ -225,26 +226,21 @@ async def async_setup(hass: HomeAssistant, config: ConfigEntry) -> bool:
             hass, update_interval, taphome_api_service=tapHome_api_service
         )
 
+        try:
+            await coordinator.async_refresh()
+        except NotImplementedError:
+            return False
+
         # register webhook handler if webhook_id is specified
         if webhook_id:
-            handle_webhook_lambda = lambda hass, webhook_id, request: handle_webhook(
-                coordinator, webhook_id
-            )
+
+            def handle_webhook_lambda(hass, webhook_id, request):
+                return handle_webhook(coordinator, webhook_id, request)
 
             webhook_name = f"Taphome-{core_id}" if core_id else "Taphome"
             async_register_webhook(
                 hass, TAPHOME_PLATFORM, webhook_name, webhook_id, handle_webhook_lambda
             )
-
-        try:
-            async with timeout(8):
-                await coordinator.async_refresh()
-                if not coordinator.last_update_success:
-                    _LOGGER.warn("TapHome devices was not discovered during startup")
-        except asyncio.TimeoutError:
-            _LOGGER.warn("TapHome devices was not discovered during startup")
-        except NotImplementedError:
-            return False
 
         hass.data[TAPHOME_PLATFORM] = {}
         for domain in domains:
@@ -324,16 +320,10 @@ def map_add_entry_requests(
 #
 
 
-async def handle_webhook(coordinator, webhook_id):
-    """Handle incoming webhook - we will trigger an update poll here"""
-    _LOGGER.info(f"Taphome webhook triggered - webhook_id: {webhook_id}")
-
-    try:
-        # ask for refresh with 8 seconds timeout
-        async with timeout(8):
-            await coordinator.async_refresh()
-            _LOGGER.info("Refresh of taphome finished")
-    except asyncio.TimeoutError:
-        _LOGGER.warn("Refresh of taphome state failed due to timeout!")
-    except NotImplementedError:
-        _LOGGER.warn("Not implemented!")
+async def handle_webhook(
+    coordinator: TapHomeDataUpdateCoordinator, webhook_id, request: Request
+):
+    """Handle incoming webhook - we will trigger an update poll here."""
+    _LOGGER.info("Taphome webhook triggered - webhook_id: %s", webhook_id)
+    all_devices_values = await request.json()
+    coordinator.update_devices_values(all_devices_values)

--- a/__init__.py
+++ b/__init__.py
@@ -1,11 +1,7 @@
 """TapHome integration."""
 
-import asyncio
 import logging
 import typing
-
-from aiohttp.web import Request
-from async_timeout import timeout
 import voluptuous
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -233,13 +229,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigEntry) -> bool:
 
         # register webhook handler if webhook_id is specified
         if webhook_id:
-
-            def handle_webhook_lambda(hass, webhook_id, request):
-                return handle_webhook(coordinator, webhook_id, request)
-
             webhook_name = f"Taphome-{core_id}" if core_id else "Taphome"
             async_register_webhook(
-                hass, TAPHOME_PLATFORM, webhook_name, webhook_id, handle_webhook_lambda
+                hass,
+                TAPHOME_PLATFORM,
+                webhook_name,
+                webhook_id,
+                coordinator.handle_webhook,
             )
 
         hass.data[TAPHOME_PLATFORM] = {}
@@ -313,17 +309,3 @@ def map_add_entry_requests(
             config_entries,
         )
     )
-
-
-#
-# webhook handler
-#
-
-
-async def handle_webhook(
-    coordinator: TapHomeDataUpdateCoordinator, webhook_id, request: Request
-):
-    """Handle incoming webhook - we will trigger an update poll here."""
-    _LOGGER.info("Taphome webhook triggered - webhook_id: %s", webhook_id)
-    all_devices_values = await request.json()
-    coordinator.update_devices_values(all_devices_values)

--- a/__init__.py
+++ b/__init__.py
@@ -280,17 +280,6 @@ def read_from_config_or_default(config: dict, key: str, default_value) -> typing
         return default_value
 
 
-# def map_config_entries(
-#     config_entry, platform_config: list
-# ) -> list[TapHomeConfigEntry]:
-#     return list(
-#         map(
-#             lambda device_config: config_entry(device_config),
-#             platform_config,
-#         )
-#     )
-
-
 def map_config_entries(config_entry, platform_config: list) -> list[TapHomeConfigEntry]:
     return list(map(config_entry, platform_config))
 
@@ -301,15 +290,13 @@ def map_add_entry_requests(
     coordinator: TapHomeDataUpdateCoordinator,
     tapHome_api_service: TapHomeApiService,
 ) -> list[AddEntryRequest]:
-    return list(
-        map(
-            lambda config_entry: AddEntryRequest(
-                core_config_entry,
-                config_entry,
-                config_entry.id,
-                coordinator,
-                tapHome_api_service,
-            ),
-            config_entries,
+    return [
+        AddEntryRequest(
+            core_config_entry,
+            config_entry,
+            config_entry.id,
+            coordinator,
+            tapHome_api_service,
         )
-    )
+        for config_entry in config_entries
+    ]

--- a/__init__.py
+++ b/__init__.py
@@ -280,23 +280,27 @@ def read_from_config_or_default(config: dict, key: str, default_value) -> typing
         return default_value
 
 
-def map_config_entries(
-    config_entry, platform_config: typing.List
-) -> typing.List[TapHomeConfigEntry]:
-    return list(
-        map(
-            lambda device_config: config_entry(device_config),
-            platform_config,
-        )
-    )
+# def map_config_entries(
+#     config_entry, platform_config: list
+# ) -> list[TapHomeConfigEntry]:
+#     return list(
+#         map(
+#             lambda device_config: config_entry(device_config),
+#             platform_config,
+#         )
+#     )
+
+
+def map_config_entries(config_entry, platform_config: list) -> list[TapHomeConfigEntry]:
+    return list(map(config_entry, platform_config))
 
 
 def map_add_entry_requests(
     core_config_entry: TapHomeCoreConfigEntry,
-    config_entries: typing.List[TapHomeConfigEntry],
+    config_entries: list[TapHomeConfigEntry],
     coordinator: TapHomeDataUpdateCoordinator,
     tapHome_api_service: TapHomeApiService,
-) -> typing.List[AddEntryRequest]:
+) -> list[AddEntryRequest]:
     return list(
         map(
             lambda config_entry: AddEntryRequest(

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,8 @@
 ## 2024.11.0
 - Add support for new TapHome 2024.2 variable types
 - New Time entity type.
+- Notify user when using device not exposed in TapHome API
+- Improved communication with TapHome Core for better efficiency: data is now refreshed using webhook updates.
 
 ## 2024.8.0
 - Introduce `close_threshold` for covers

--- a/climate.py
+++ b/climate.py
@@ -148,7 +148,7 @@ class TapHomeModeClimateController(
 
     @property
     def hvac_mode(self) -> HVACMode | None:
-        if not self.taphome_state is None:
+        if self.taphome_state is not None:
             modes = {
                 0: HVACMode.OFF,
                 1: HVACMode.HEAT,

--- a/coordinator.py
+++ b/coordinator.py
@@ -103,15 +103,25 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         taphome_state_change_handler,
     ) -> None:
         device = self.get_device_data(taphome_device_id)
-        device.attach_taphome_device_change_handler(taphome_device_change_handler)
-        device.attach_taphome_state_change_handler(taphome_state_change_handler)
+        if device is None:
+            _LOGGER.error(
+                "No device with id %s has been exposed in the TapHome API",
+                taphome_device_id,
+            )
+        else:
+            device.attach_taphome_device_change_handler(taphome_device_change_handler)
+            device.attach_taphome_state_change_handler(taphome_state_change_handler)
 
     def get_device(self, taphome_device_id: int) -> Device:
         device = self.get_device_data(taphome_device_id)
+        if device is None:
+            return None
         return device.taphome_device
 
     def get_state(self, taphome_device_id: int, state_type):
         device = self.get_device_data(taphome_device_id)
+        if device is None:
+            return None
         return device.get_state(state_type)
 
     async def _async_update_data(self):
@@ -195,12 +205,7 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self, taphome_device_id: int
     ) -> TapHomeDataUpdateCoordinatorDevice:
         if taphome_device_id not in self._devices:
-            _LOGGER.error(
-                "No device with id %s has been exposed in the TapHome API",
-                taphome_device_id,
-            )
-            # return an empty object to preserve backward compactability.
-            return TapHomeDataUpdateCoordinatorDevice()
+            return None
         return self._devices[taphome_device_id]
 
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -12,7 +12,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import TAPHOME_PLATFORM
-from .taphome_sdk import *
+from .taphome_sdk.taphome_api_service import Device, TapHomeApiService
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,6 +70,7 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self.taphome_api_service = taphome_api_service
         self._was_devices_discovered = False
         self._devices = {}
+        self._last_all_devices_values = {}
         update_interval = timedelta(seconds=update_interval)
         super().__init__(
             hass, _LOGGER, name=TAPHOME_PLATFORM, update_interval=update_interval
@@ -84,6 +85,7 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         device = self.get_device_data(taphome_device_id)
         device.taphome_state_type = taphome_state_type
+        self.restore_last_known_device_state(taphome_device_id)
         device.attach_taphome_device_change_handler(taphome_device_change_handler)
         device.attach_taphome_state_change_handler(taphome_state_change_handler)
 
@@ -99,12 +101,15 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         """Fetch data from TapHome."""
         try:
             await self.async_discovery_devices()
-            await self.async_update_devices_values()
+            await self.async_refresh_all_devices_values()
             return self._devices
 
         except ClientResponseError as ex:
             if ex.status == 501:
-                raise NotImplementedError()  # NotImplementedError is reraised to fail integration loading. Core don't support get all devices api endpoint
+                _LOGGER.error(
+                    "Core don't support get all devices api endpoint. Please update your TapHome Core"
+                )
+                raise NotImplementedError  # NotImplementedError is reraised to fail integration loading.
             else:
                 exception_info = f"{ex.code} - {ex.request_info.url} {ex.message}"
                 raise UpdateFailed(
@@ -112,7 +117,7 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
                 ) from ex
 
         except Exception as ex:
-            raise UpdateFailed() from ex
+            raise UpdateFailed from ex
 
     async def async_discovery_devices(self) -> None:
         if not self._was_devices_discovered:
@@ -123,28 +128,43 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
                     device.taphome_device = taphome_device
                 self._was_devices_discovered = True
 
-    async def async_update_devices_values(self) -> None:
-        all_devices_values = (
+    async def async_refresh_all_devices_values(self) -> None:
+        self._last_all_devices_values = (
             await self.taphome_api_service.async_get_all_devices_values()
         )
-        if all_devices_values is not None:
-            for device_value in all_devices_values["devices"]:
-                device = self.get_device_data(device_value["deviceId"])
-
-                if device.taphome_state_type is not None:
-                    current_state = device.taphome_state_type(device_value["values"])
-                    if not device.taphome_state == current_state:
-                        device.taphome_state = current_state
-
+        if self._last_all_devices_values is not None:
+            self.update_devices_values(self._last_all_devices_values)
         else:
-            for device_id in self._devices:
-                self._devices[device_id].taphome_state = None
-            raise UpdateFailed()
+            for device in self._devices.items():
+                device.taphome_state = None
+            raise UpdateFailed
+
+    def update_devices_values(self, new_values: dict):
+        for new_device_value in new_values["devices"]:
+            self.update_device_values(new_device_value)
+        self.async_set_updated_data(self._devices)
+
+    def restore_last_known_device_state(self, device_id: str):
+        for device in self._last_all_devices_values["devices"]:
+            if device_id == device["deviceId"]:
+                self.update_device_values(device)
+
+    def update_device_values(self, new_device_value):
+        new_device_id = new_device_value["deviceId"]
+        new_device_values = new_device_value["values"]
+
+        device = self.get_device_data(new_device_id)
+
+        # taphome_state_type je zaregistrován až později, proto zde nic není při prvním loadu
+        if device.taphome_state_type is not None:
+            current_state = device.taphome_state_type(new_device_values)
+            if device.taphome_state != current_state:
+                device.taphome_state = current_state
 
     def get_device_data(
         self, taphome_device_id: int
     ) -> TapHomeDataUpdateCoordinatorDevice:
-        if not taphome_device_id in self._devices:
+        if taphome_device_id not in self._devices:
             self._devices[taphome_device_id] = TapHomeDataUpdateCoordinatorDevice()
         return self._devices[taphome_device_id]
 
@@ -176,12 +196,12 @@ class TapHomeDataUpdateCoordinatorObject(Generic[TState]):
 
     @callback
     def handle_taphome_device_change(self) -> None:
-        """This method is called when taphome_device is changed"""
+        """This method is called when taphome_device is changed."""
         pass
 
     @callback
     def handle_taphome_state_change(self) -> None:
-        """This method is called when taphome_state is changed"""
+        """This method is called when taphome_state is changed."""
         pass
 
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -105,7 +105,7 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         device = self.get_device_data(taphome_device_id)
         if device is None:
             _LOGGER.error(
-                "No device with id %s has been exposed in the TapHome API",
+                "TapHome register entity failed. Device with id %s has not been exposed in the TapHome API",
                 taphome_device_id,
             )
         else:

--- a/coordinator.py
+++ b/coordinator.py
@@ -141,8 +141,9 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
             discovery_devices = await self.taphome_api_service.async_discovery_devices()
             if discovery_devices is not None:
                 for taphome_device in discovery_devices:
-                    device = self.get_device_data(taphome_device.id)
+                    device = TapHomeDataUpdateCoordinatorDevice()
                     device.taphome_device = taphome_device
+                    self._devices[taphome_device.id] = device
                 self._was_devices_discovered = True
 
     async def async_refresh_all_devices_values(self) -> None:
@@ -194,7 +195,12 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self, taphome_device_id: int
     ) -> TapHomeDataUpdateCoordinatorDevice:
         if taphome_device_id not in self._devices:
-            self._devices[taphome_device_id] = TapHomeDataUpdateCoordinatorDevice()
+            _LOGGER.error(
+                "No device with id %s has been exposed in the TapHome API",
+                taphome_device_id,
+            )
+            # return an empty object to preserve backward compactability.
+            return TapHomeDataUpdateCoordinatorDevice()
         return self._devices[taphome_device_id]
 
 

--- a/coordinator.py
+++ b/coordinator.py
@@ -1,6 +1,9 @@
 """Provides the taphome DataUpdateCoordinator."""
 
+from aiohttp.web import Request
+
 # from .switch import TapHomeSwitch
+import copy
 from datetime import timedelta
 import logging
 from types import TracebackType
@@ -8,7 +11,7 @@ from typing import Generic, TypeVar
 
 from aiohttp.client_reqrep import ClientResponseError
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import TAPHOME_PLATFORM
@@ -25,8 +28,9 @@ class TapHomeDataUpdateCoordinatorDevice:
         self._taphome_device_change_listeners = []
         self._taphome_state_change_listeners = []
         self._taphome_device = None
-        self._taphome_state = None
-        self.taphome_state_type = None
+        self._taphome_values = None
+        self._taphome_state_types = []
+        self._taphome_states = {}
 
     @property
     def taphome_device(self):
@@ -45,13 +49,30 @@ class TapHomeDataUpdateCoordinatorDevice:
             taphome_device_change_handler()
 
     @property
-    def taphome_state(self):
-        return self._taphome_state
+    def taphome_values(self):
+        return self._taphome_values
 
-    @taphome_state.setter
-    def taphome_state(self, new_state):
-        self._taphome_state = new_state
+    @taphome_values.setter
+    def taphome_values(self, new_state):
+        self._taphome_values = new_state
+        self.update_taphome_states()
         self.invoke_taphome_state_change()
+
+    def get_state(self, state_type):
+        if state_type not in self._taphome_state_types:
+            self._taphome_state_types.append(state_type)
+
+        if state_type not in self._taphome_states:
+            self.update_taphome_state(state_type)
+        return self._taphome_states[state_type]
+
+    def update_taphome_states(self):
+        for state_type in self._taphome_state_types:
+            self.update_taphome_state(state_type)
+
+    def update_taphome_state(self, state_type):
+        state = None if self.taphome_values is None else state_type(self.taphome_values)
+        self._taphome_states[state_type] = state
 
     def attach_taphome_state_change_handler(self, taphome_state_change_handler):
         self._taphome_state_change_listeners.append(taphome_state_change_handler)
@@ -70,7 +91,6 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         self.taphome_api_service = taphome_api_service
         self._was_devices_discovered = False
         self._devices = {}
-        self._last_all_devices_values = {}
         update_interval = timedelta(seconds=update_interval)
         super().__init__(
             hass, _LOGGER, name=TAPHOME_PLATFORM, update_interval=update_interval
@@ -79,13 +99,10 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
     def register_entity(
         self,
         taphome_device_id: int,
-        taphome_state_type,
         taphome_device_change_handler,
         taphome_state_change_handler,
     ) -> None:
         device = self.get_device_data(taphome_device_id)
-        device.taphome_state_type = taphome_state_type
-        self.restore_last_known_device_state(taphome_device_id)
         device.attach_taphome_device_change_handler(taphome_device_change_handler)
         device.attach_taphome_state_change_handler(taphome_state_change_handler)
 
@@ -93,9 +110,9 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
         device = self.get_device_data(taphome_device_id)
         return device.taphome_device
 
-    def get_state(self, taphome_device_id: int):
+    def get_state(self, taphome_device_id: int, state_type):
         device = self.get_device_data(taphome_device_id)
-        return device.taphome_state
+        return device.get_state(state_type)
 
     async def _async_update_data(self):
         """Fetch data from TapHome."""
@@ -129,37 +146,49 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
                 self._was_devices_discovered = True
 
     async def async_refresh_all_devices_values(self) -> None:
-        self._last_all_devices_values = (
+        last_all_devices_values = (
             await self.taphome_api_service.async_get_all_devices_values()
         )
-        if self._last_all_devices_values is not None:
-            self.update_devices_values(self._last_all_devices_values)
+        if last_all_devices_values is not None:
+            self.update_devices_values(last_all_devices_values, True)
         else:
             for device in self._devices.items():
                 device.taphome_state = None
             raise UpdateFailed
 
-    def update_devices_values(self, new_values: dict):
-        for new_device_value in new_values["devices"]:
-            self.update_device_values(new_device_value)
+    async def handle_webhook(
+        self, hass: HomeAssistant, webhook_id: str, request: Request
+    ):
+        """Handle incoming webhook - we will trigger an update poll here."""
+        _LOGGER.info("Taphome webhook triggered - webhook_id: %s", webhook_id)
+        all_devices_values = await request.json()
+        self.update_devices_values(all_devices_values)
+
+    def update_devices_values(self, changed_values: dict, force: bool = False):
+        for changed_device in changed_values["devices"]:
+            device_id = changed_device["deviceId"]
+            device_changed_values = changed_device["values"]
+            device = self.get_device_data(device_id)
+            device_new_values = (
+                device_changed_values
+                if force
+                else self.apply_changes(device, device_changed_values)
+            )
+            if device.taphome_values != device_new_values:
+                device.taphome_values = device_new_values
         self.async_set_updated_data(self._devices)
 
-    def restore_last_known_device_state(self, device_id: str):
-        for device in self._last_all_devices_values["devices"]:
-            if device_id == device["deviceId"]:
-                self.update_device_values(device)
+    def apply_changes(
+        self, device: TapHomeDataUpdateCoordinatorDevice, device_changed_values: dict
+    ):
+        new_values = copy.deepcopy(device.taphome_values)
+        for changed_value in device_changed_values:
+            for value_entry in new_values:
+                if value_entry["valueTypeId"] == changed_value["valueTypeId"]:
+                    value_entry["value"] = changed_value["value"]
+                    break
 
-    def update_device_values(self, new_device_value):
-        new_device_id = new_device_value["deviceId"]
-        new_device_values = new_device_value["values"]
-
-        device = self.get_device_data(new_device_id)
-
-        # taphome_state_type je zaregistrován až později, proto zde nic není při prvním loadu
-        if device.taphome_state_type is not None:
-            current_state = device.taphome_state_type(new_device_values)
-            if device.taphome_state != current_state:
-                device.taphome_state = current_state
+        return new_values
 
     def get_device_data(
         self, taphome_device_id: int
@@ -177,18 +206,20 @@ class TapHomeDataUpdateCoordinatorObject(Generic[TState]):
         taphome_state_type,
     ):
         self._taphome_device_id = taphome_device_id
+        self._taphome_state_type = taphome_state_type
         self.coordinator = coordinator
 
         coordinator.register_entity(
             taphome_device_id,
-            taphome_state_type,
             self.handle_taphome_device_change,
             self.handle_taphome_state_change,
         )
 
     @property
     def taphome_state(self) -> TState:
-        return self.coordinator.get_state(self._taphome_device_id)
+        return self.coordinator.get_state(
+            self._taphome_device_id, self._taphome_state_type
+        )
 
     @property
     def taphome_device(self) -> Device:

--- a/coordinator.py
+++ b/coordinator.py
@@ -138,12 +138,12 @@ class TapHomeDataUpdateCoordinator(DataUpdateCoordinator):
                 )
                 raise NotImplementedError  # NotImplementedError is reraised to fail integration loading.
             else:
-                exception_info = f"{ex.code} - {ex.request_info.url} {ex.message}"
-                raise UpdateFailed(
-                    f"Invalid response from API: {exception_info}"
-                ) from ex
+                exception_message = f"Invalid response from API: {ex.code} - {ex.request_info.url} {ex.message}"
+                _LOGGER.error(exception_message)
+                raise UpdateFailed(exception_message) from ex
 
         except Exception as ex:
+            _LOGGER.exception("TapHome data update failed")
             raise UpdateFailed from ex
 
     async def async_discovery_devices(self) -> None:

--- a/humidifier.py
+++ b/humidifier.py
@@ -52,7 +52,7 @@ class TapHomeHumidifier(TapHomeEntity[HumidifierState], HumidifierEntity):
     @property
     def is_on(self):
         """Returns if the device is on or not."""
-        if not self.taphome_state is None:
+        if self.taphome_state is not None:
             return self.taphome_state.switch_state == SwitchStates.ON
 
     @property

--- a/taphome_sdk/taphome_api_service.py
+++ b/taphome_sdk/taphome_api_service.py
@@ -32,12 +32,14 @@ class TapHomeApiService:
                 try:
                     devices.append(Device.create(device))
                 except Exception:
-                    _LOGGER.error(
+                    _LOGGER.exception(
                         "TapHome Device.create failed \n %s \n %s", device, json
                     )
             return devices
         except Exception:
-            _LOGGER.error("TapHome request async_discovery_devices failed: %s", json)
+            _LOGGER.exception(
+                "TapHome request async_discovery_devices failed: %s", json
+            )
 
     async def async_get_location(self):
         json = {}
@@ -45,7 +47,7 @@ class TapHomeApiService:
             json = await self.taphome_api_service.async_api_get("location")
             return Location.create(json)
         except Exception:
-            _LOGGER.error("TapHome request async_get_location failed: %s", json)
+            _LOGGER.exception("TapHome request async_get_location failed: %s", json)
 
     async def async_get_all_devices_values(self) -> dict:
         deviceInfo = None
@@ -53,11 +55,11 @@ class TapHomeApiService:
             return await self.taphome_api_service.async_api_get("getAllDevicesValues")
         except Exception as ex:
             if hasattr(ex, "status") and ex.status == 501:
-                _LOGGER.error(
+                _LOGGER.exception(
                     "TapHome request failed: Request not supported by core! Please update your core to 2021.2 or newer"
                 )
                 raise
-            _LOGGER.error(
+            _LOGGER.exception(
                 "TapHome request async_get_all_devices_values failed: %s", deviceInfo
             )
             return None
@@ -70,7 +72,7 @@ class TapHomeApiService:
             )
             return deviceInfo["values"]
         except Exception:
-            _LOGGER.error(
+            _LOGGER.exception(
                 "TapHome request async_get_device_values failed: %s", deviceInfo
             )
             return None
@@ -104,7 +106,7 @@ class TapHomeApiService:
             ):
                 was_values_changed = True
         except Exception:
-            _LOGGER.error(
+            _LOGGER.exception(
                 "TapHome async_set_device_values for %s fails %s", device_id, json
             )
 


### PR DESCRIPTION
Previously, when a webhook was received, all data was updated. The webhook now also contains information about changed devices. Now data is updated based on webhook body and once per minute (according to `update_interval` setting) all data is updated. In case of communication failure.