### PR TITLE
Fix service device id and api client

### DIFF
--- a/taphome_sdk/fan_service.py
+++ b/taphome_sdk/fan_service.py
@@ -10,10 +10,11 @@ class FanState(PercentageState):
 class FanService:
     def __init__(self, taphome_api_service: TapHomeApiService):
         self.percentage_service = PercentageService(taphome_api_service)
+        self.taphome_api_service = taphome_api_service
 
     async def async_get_state(self, device: Device) -> FanState:
         fan_values = await self.taphome_api_service.async_get_device_values(
-            device.deviceId
+            device.id
         )
         return FanState(fan_values)
 

--- a/taphome_sdk/humidifier_service.py
+++ b/taphome_sdk/humidifier_service.py
@@ -10,10 +10,11 @@ class HumidifierState(PercentageState):
 class HumidifierService:
     def __init__(self, taphome_api_service: TapHomeApiService):
         self.percentage_service = PercentageService(taphome_api_service)
+        self.taphome_api_service = taphome_api_service
 
     async def async_get_state(self, device: Device) -> HumidifierState:
         humidifier_values = await self.taphome_api_service.async_get_device_values(
-            device.deviceId
+            device.id
         )
         return HumidifierState(humidifier_values)
 

--- a/taphome_sdk/light_service.py
+++ b/taphome_sdk/light_service.py
@@ -32,7 +32,7 @@ class LightService:
 
     async def async_get_state(self, device: Device) -> LightState:
         light_values = await self.tapHomeApiService.async_get_device_values(
-            device.deviceId
+            device.id
         )
 
         return LightState(light_values)

--- a/taphome_sdk/percentage_service.py
+++ b/taphome_sdk/percentage_service.py
@@ -42,7 +42,7 @@ class PercentageService:
 
     async def async_get_state(self, device: Device) -> PercentageState:
         percentage_values = await self.taphome_api_service.async_get_device_values(
-            device.deviceId
+            device.id
         )
         return PercentageState(percentage_values)
 

--- a/taphome_sdk/thermostat_service.py
+++ b/taphome_sdk/thermostat_service.py
@@ -27,7 +27,7 @@ class ThermostatService:
     async def async_get_state(self, device: Device) -> ThermostatState:
         try:
             thermostat_values = await self.taphome_api_service.async_get_device_values(
-                device.deviceId
+                device.id
             )
 
             return ThermostatState(thermostat_values)

--- a/taphome_sdk/valve_service.py
+++ b/taphome_sdk/valve_service.py
@@ -10,10 +10,11 @@ class ValveState(PercentageState):
 class ValveService:
     def __init__(self, taphome_api_service: TapHomeApiService):
         self.percentage_service = PercentageService(taphome_api_service)
+        self.taphome_api_service = taphome_api_service
 
     async def async_get_state(self, device: Device) -> ValveState:
         valve_values = await self.taphome_api_service.async_get_device_values(
-            device.deviceId
+            device.id
         )
         return ValveState(valve_values)
 


### PR DESCRIPTION
## Summary
- fix missing API service reference in several service classes
- use `device.id` instead of the nonexistent `device.deviceId`

## Testing
- `python -m py_compile taphome_sdk/*.py`