### PR TITLE
Refactor star imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,26 @@ from .add_entry_request import AddEntryRequest
 from .binary_sensor import BinarySensorConfigEntry
 from .button import ButtonConfigEntry
 from .climate import ClimateConfigEntry
-from .const import *
+from .const import (
+    CONF_BINARY_SENSORS,
+    CONF_BUTTONS,
+    CONF_CLIMATES,
+    CONF_CORES,
+    CONF_COVERS,
+    CONF_FAN,
+    CONF_HUMIDIFIER,
+    CONF_LANGUAGE,
+    CONF_MULTIVALUE_SWITCHES,
+    CONF_SENSORS,
+    CONF_SWITCHES,
+    CONF_TIMES,
+    CONF_UPDATE_INTERVAL,
+    CONF_VALVE,
+    CONF_API_URL,
+    TAPHOME_PLATFORM,
+    USE_DESCRIPTION_AS_ENTITY_ID,
+    USE_DESCRIPTION_AS_NAME,
+)
 from .coordinator import TapHomeDataUpdateCoordinator
 from .cover import CoverConfigEntry
 from .humidifier import HumidifierConfigEntry
@@ -44,7 +63,7 @@ from .sensor import SensorConfigEntry
 from .switch import SwitchConfigEntry
 from .taphome_core_config_entry import TapHomeCoreConfigEntry
 from .taphome_entity import TapHomeConfigEntry
-from .taphome_sdk import *
+from .taphome_sdk import TapHomeApiService, TapHomeHttpClientFactory
 from .valve import ValveConfigEntry
 
 _LOGGER = logging.getLogger(__name__)

--- a/add_entry_request.py
+++ b/add_entry_request.py
@@ -1,7 +1,7 @@
 from .coordinator import TapHomeDataUpdateCoordinator
 from .taphome_core_config_entry import TapHomeCoreConfigEntry
 from .taphome_entity import TapHomeConfigEntry
-from .taphome_sdk import *
+from .taphome_sdk import TapHomeApiService
 
 
 class AddEntryRequest:

--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -13,9 +13,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .add_entry_request import AddEntryRequest
 from .const import TAPHOME_PLATFORM
-from .coordinator import TapHomeDataUpdateCoordinator
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, TapHomeDataUpdateCoordinatorObject
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import TapHomeState, ValueType
 
 
 class TapHomeIsAliveSensor(BinarySensorEntity):

--- a/button.py
+++ b/button.py
@@ -6,8 +6,9 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_BUTTONS, TAPHOME_PLATFORM
-from .taphome_entity import *
-from .taphome_sdk import *
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import ButtonAction, ButtonService, TapHomeState
 
 
 class ButtonConfigEntry(TapHomeConfigEntry):

--- a/climate.py
+++ b/climate.py
@@ -16,9 +16,24 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_CLIMATES, TAPHOME_PLATFORM
-from .coordinator import TapHomeDataUpdateCoordinator
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import (
+    TapHomeDataUpdateCoordinator,
+    TapHomeDataUpdateCoordinatorObject,
+    UpdateTapHomeState,
+    TState,
+)
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import (
+    MultiValueSwitchService,
+    MultiValueSwitchState,
+    SwitchService,
+    SwitchState,
+    TapHomeApiService,
+    ThermostatService,
+    ThermostatState,
+    ValueType,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/cover.py
+++ b/cover.py
@@ -15,9 +15,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import CoverService, CoverState
 
 
 class CoverConfigEntry(TapHomeConfigEntry):

--- a/fan.py
+++ b/fan.py
@@ -9,9 +9,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_FAN, TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import FanService, FanState, SwitchStates
 
 
 class TapHomeFan(TapHomeEntity[FanState], FanEntity):

--- a/humidifier.py
+++ b/humidifier.py
@@ -14,9 +14,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_HUMIDIFIER, TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import HumidifierService, HumidifierState, SwitchStates, ValueType
 
 
 class HumidifierConfigEntry(TapHomeConfigEntry):

--- a/light.py
+++ b/light.py
@@ -17,9 +17,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import LightService, LightState, SwitchStates, ValueType
 
 
 class TapHomeLight(TapHomeEntity[LightState], LightEntity):

--- a/select.py
+++ b/select.py
@@ -7,9 +7,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_MULTIVALUE_SWITCHES, TAPHOME_PLATFORM
-from .coordinator import TapHomeDataUpdateCoordinator
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import MultiValueSwitchService, MultiValueSwitchState, ValueType
 
 
 class TapHomeSelectOption:

--- a/sensor.py
+++ b/sensor.py
@@ -30,9 +30,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .add_entry_request import AddEntryRequest
 from .const import TAPHOME_PLATFORM
-from .coordinator import TapHomeDataUpdateCoordinator
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, TapHomeDataUpdateCoordinatorObject
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import TapHomeState, ValueType
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/switch.py
+++ b/switch.py
@@ -8,9 +8,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import SwitchService, SwitchState, SwitchStates
 
 
 class SwitchConfigEntry(TapHomeConfigEntry):

--- a/taphome_entity.py
+++ b/taphome_entity.py
@@ -3,9 +3,12 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .coordinator import *
+from .coordinator import (
+    TapHomeDataUpdateCoordinator,
+    TapHomeDataUpdateCoordinatorObject,
+    TState,
+)
 from .taphome_core_config_entry import TapHomeCoreConfigEntry
-from .taphome_sdk import *
 
 
 class TapHomeConfigEntry:

--- a/valve.py
+++ b/valve.py
@@ -7,9 +7,10 @@ from homeassistant.core import HomeAssistant
 
 from .add_entry_request import AddEntryRequest
 from .const import CONF_VALVE, TAPHOME_PLATFORM
-from .coordinator import *
-from .taphome_entity import *
-from .taphome_sdk import *
+from .coordinator import TapHomeDataUpdateCoordinator, UpdateTapHomeState
+from .taphome_core_config_entry import TapHomeCoreConfigEntry
+from .taphome_entity import TapHomeConfigEntry, TapHomeEntity
+from .taphome_sdk import SwitchStates, ValveService, ValveState
 
 
 class ValveConfigEntry(TapHomeConfigEntry):


### PR DESCRIPTION
## Summary
- remove wildcard imports across the integration
- use explicit imports for clarity

## Testing
- `python -m py_compile *.py taphome_sdk/*.py`