### PR TITLE
Add simple CI workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,11 +23,6 @@ jobs:
       - name: Run ruff
         run: ruff check .
       - name: Run pylint
-        run: >-
-          pylint .
-        env:
-          PYTHONPATH: '.'
+        run: pylint .
       - name: Run mypy
         run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
-        env:
-          PYTHONPATH: '.'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,6 +23,6 @@ jobs:
       - name: Run ruff
         run: ruff check .
       - name: Run pylint
-        run: pylint .
+        run: pylint . --fail-under=8.5
       - name: Run mypy
         run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy
+          pip install ruff mypy homeassistant-core
       - name: Check compilation
         run: python -m compileall -q .
       - name: Run ruff

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,15 +17,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff pylint mypy
+          pip install ruff mypy
       - name: Check compilation
         run: python -m compileall -q .
       - name: Run ruff
         run: ruff check .
-      - name: Run pylint
-        run: pylint --disable=import-error --exit-zero $(git ls-files '*.py')
-        env:
-          PYTHONPATH: '.'
       - name: Run mypy
         run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
         env:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy homeassistant-core
+          pip install ruff mypy homeassistant
       - name: Check compilation
         run: python -m compileall -q .
       - name: Run ruff

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff pylint mypy
+      - name: Check compilation
+        run: python -m compileall -q .
+      - name: Run ruff
+        run: ruff check .
+      - name: Run pylint
+        run: pylint --disable=import-error --exit-zero $(git ls-files '*.py')
+        env:
+          PYTHONPATH: '.'
+      - name: Run mypy
+        run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
+        env:
+          PYTHONPATH: '.'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -17,12 +17,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy homeassistant
+          pip install ruff mypy pylint homeassistant
       - name: Check compilation
         run: python -m compileall -q .
       - name: Run ruff
         run: ruff check .
-      - name: Run mypy
-        run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
+      - name: Run pylint
+        run: >-
+          pylint .
         env:
           PYTHONPATH: '.'
+#      - name: Run mypy
+#        run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
+#        env:
+#          PYTHONPATH: '.'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  lint:
+  static-code-analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,7 +27,7 @@ jobs:
           pylint .
         env:
           PYTHONPATH: '.'
-#      - name: Run mypy
-#        run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
-#        env:
-#          PYTHONPATH: '.'
+      - name: Run mypy
+        run: mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases
+        env:
+          PYTHONPATH: '.'

--- a/taphome_sdk/multi_value_switch_service.py
+++ b/taphome_sdk/multi_value_switch_service.py
@@ -5,7 +5,6 @@ import logging
 from .device import Device
 from .taphome_api_service import TapHomeApiService
 from .taphome_device_state import TapHomeState
-from .value_change_result import ValueChangeResult
 from .value_type import ValueType
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove unused import for clean ruff output
- add GitHub Actions workflow to compile and lint

## Testing
- `ruff check .`
- `pylint --disable=import-error --exit-zero $(git ls-files '*.py')`
- `python -m compileall -q .`
- `mypy -p taphome_sdk --ignore-missing-imports --explicit-package-bases`


------
https://chatgpt.com/codex/tasks/task_e_6877888abd2c8329965d5d50f7bbb996