### PR TITLE
Add translations for additional languages

### DIFF
--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "device_not_exposed": {
+      "title": "Zařízení {device_id} není zveřejněno pro core{core_id}",
+      "description": "Zařízení {device_id} nastavené pro core{core_id} není dostupné v TapHome API. Zkontrolujte prosím nastavení TapHome."
+    },
+    "core_unavailable": {
+      "title": "Připojení k TapHome core{core_id} se nezdařilo",
+      "description": "Home Assistant se nemůže spojit s TapHome core{core_id}."
+    }
+  }
+}

--- a/translations/de.json
+++ b/translations/de.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "device_not_exposed": {
+      "title": "Gerät {device_id} ist für Core{core_id} nicht freigegeben",
+      "description": "Das Gerät {device_id}, das für Core{core_id} konfiguriert ist, ist in der TapHome-API nicht freigegeben. Bitte überprüfen Sie Ihre TapHome-Einstellungen."
+    },
+    "core_unavailable": {
+      "title": "Verbindung zum TapHome Core{core_id} fehlgeschlagen",
+      "description": "Home Assistant kann nicht mit dem TapHome Core{core_id} kommunizieren."
+    }
+  }
+}

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "device_not_exposed": {
+      "title": "A(z) {device_id} eszköz nincs közzétéve a(z) core{core_id} számára",
+      "description": "A(z) {device_id} eszköz, amely core{core_id} számára van konfigurálva, nincs kitéve a TapHome API-ban. Ellenőrizze a TapHome beállításait."
+    },
+    "core_unavailable": {
+      "title": "Nem sikerült csatlakozni a TapHome core{core_id} rendszerhez",
+      "description": "A Home Assistant nem tud kommunikálni a TapHome core{core_id} rendszerrel."
+    }
+  }
+}

--- a/translations/it.json
+++ b/translations/it.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "device_not_exposed": {
+      "title": "Dispositivo {device_id} non esposto per core{core_id}",
+      "description": "Il dispositivo {device_id} configurato per core{core_id} non è esposto nelle API di TapHome. Verifica la tua configurazione di TapHome."
+    },
+    "core_unavailable": {
+      "title": "Connessione al TapHome core{core_id} non riuscita",
+      "description": "Home Assistant non può comunicare con il TapHome core{core_id}."
+    }
+  }
+}

--- a/translations/sk.json
+++ b/translations/sk.json
@@ -1,0 +1,12 @@
+{
+  "issues": {
+    "device_not_exposed": {
+      "title": "Zariadenie {device_id} nie je vystavené pre core{core_id}",
+      "description": "Zariadenie {device_id} nakonfigurované pre core{core_id} nie je vystavené v TapHome API. Skontrolujte nastavenie TapHome."
+    },
+    "core_unavailable": {
+      "title": "Pripojenie k TapHome core{core_id} zlyhalo",
+      "description": "Home Assistant sa nevie pripojiť k TapHome core{core_id}."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- provide TapHome issue translations in German, Czech, Slovak, Italian and Hungarian

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68871a6d95448329950856b332a54567