### PR TITLE
Add minimal pytest tests and CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,13 @@ jobs:
       package: "pylint"
       command: "pylint . --fail-under=9.4"
 
+  tests:
+    needs: prepare-python-env
+    uses: ./.github/workflows/python-check.yml
+    with:
+      package: "pytest pytest-asyncio"
+      command: "pytest"
+
   validate-hacs:
     runs-on: ubuntu-latest
     steps:

--- a/tests/test_entity_coordinator.py
+++ b/tests/test_entity_coordinator.py
@@ -1,0 +1,72 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+homeassistant_spec = importlib.util.find_spec("homeassistant")
+aiohttp_spec = importlib.util.find_spec("aiohttp")
+if homeassistant_spec is None or aiohttp_spec is None:
+    pytest.skip("homeassistant or aiohttp not installed", allow_module_level=True)
+
+from taphome_entity import TapHomeEntity  # noqa: E402
+from coordinator import (  # noqa: E402
+    TapHomeDataUpdateCoordinator,
+    TapHomeDataUpdateCoordinatorDevice,
+)
+
+
+def test_conversion_helpers_round_trip() -> None:
+    original = 0.6
+    ha_byte = TapHomeEntity.convert_taphome_byte_to_ha(original)
+    assert ha_byte == pytest.approx(153.0)
+    assert TapHomeEntity.convert_ha_byte_to_taphome(ha_byte) == pytest.approx(original)
+
+    ha_percent = TapHomeEntity.convert_taphome_percentage_to_ha(original)
+    assert ha_percent == 60
+    assert TapHomeEntity.convert_ha_percentage_to_taphome(ha_percent) == pytest.approx(original)
+
+
+def test_convert_bool_values() -> None:
+    assert TapHomeEntity.convert_taphome_bool_to_ha(1) is True
+    assert TapHomeEntity.convert_taphome_bool_to_ha(0) is False
+    assert TapHomeEntity.convert_taphome_bool_to_ha(42) is None
+    assert TapHomeEntity.convert_taphome_bool_to_ha(None) is None
+
+
+def test_apply_changes_updates_existing_value() -> None:
+    device = TapHomeDataUpdateCoordinatorDevice()
+    device.taphome_values = [
+        {"valueTypeId": 1, "value": 10},
+        {"valueTypeId": 2, "value": 20},
+    ]
+
+    coordinator = TapHomeDataUpdateCoordinator.__new__(TapHomeDataUpdateCoordinator)
+    changed = [{"valueTypeId": 1, "value": 15}]
+
+    new_values = coordinator.apply_changes(device, changed)
+
+    assert new_values == [
+        {"valueTypeId": 1, "value": 15},
+        {"valueTypeId": 2, "value": 20},
+    ]
+    assert device.taphome_values == [
+        {"valueTypeId": 1, "value": 10},
+        {"valueTypeId": 2, "value": 20},
+    ]
+
+
+def test_apply_changes_ignores_unknown_value() -> None:
+    device = TapHomeDataUpdateCoordinatorDevice()
+    device.taphome_values = [{"valueTypeId": 1, "value": 10}]
+
+    coordinator = TapHomeDataUpdateCoordinator.__new__(TapHomeDataUpdateCoordinator)
+    changed = [{"valueTypeId": 2, "value": 99}]
+
+    new_values = coordinator.apply_changes(device, changed)
+
+    assert new_values == [{"valueTypeId": 1, "value": 10}]
+    assert device.taphome_values == [{"valueTypeId": 1, "value": 10}]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,11 +6,12 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from taphome_sdk import Device, SwitchStates, ValueType  # noqa: E402
-
 homeassistant_spec = importlib.util.find_spec("homeassistant")
-if homeassistant_spec is None:
-    pytest.skip("homeassistant not installed", allow_module_level=True)
+aiohttp_spec = importlib.util.find_spec("aiohttp")
+if homeassistant_spec is None or aiohttp_spec is None:
+    pytest.skip("homeassistant or aiohttp not installed", allow_module_level=True)
+
+from taphome_sdk import Device, SwitchStates, ValueType  # noqa: E402
 
 # load integration as custom_components.taphome
 spec = importlib.util.spec_from_file_location(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,142 @@
+import importlib.util
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from taphome_sdk import Device, SwitchStates, ValueType  # noqa: E402
+
+homeassistant_spec = importlib.util.find_spec("homeassistant")
+if homeassistant_spec is None:
+    pytest.skip("homeassistant not installed", allow_module_level=True)
+
+# load integration as custom_components.taphome
+spec = importlib.util.spec_from_file_location(
+    "custom_components.taphome", "__init__.py"
+)
+taphome = importlib.util.module_from_spec(spec)
+sys.modules["custom_components.taphome"] = taphome
+spec.loader.exec_module(taphome)
+
+class FakeTapHomeApiService:
+    def __init__(self, _client=None):
+        self.state = SwitchStates.ON
+
+    async def async_discovery_devices(self):
+        return [
+            Device.from_dict(
+                {
+                    "deviceId": 1,
+                    "type": "switch",
+                    "name": "Switch 1",
+                    "description": "Switch 1",
+                    "supportedValues": [
+                        {
+                            "valueTypeId": ValueType.SWITCH_STATE.value,
+                            "readOnly": False,
+                        }
+                    ],
+                }
+            )
+        ]
+
+    async def async_get_all_devices_values(self):
+        return {
+            "devices": [
+                {
+                    "deviceId": 1,
+                    "values": [
+                        {"valueTypeId": ValueType.SWITCH_STATE.value, "value": self.state.value}
+                    ],
+                }
+            ]
+        }
+
+    async def async_get_device_values(self, device_id):
+        return [
+            {"valueTypeId": ValueType.SWITCH_STATE.value, "value": self.state.value}
+        ]
+
+    async def async_set_device_values(self, device_id, values):
+        for val in values:
+            if val["ValueTypeId"] == ValueType.SWITCH_STATE.value:
+                self.state = SwitchStates(val["Value"])
+
+    def create_device_value(self, value_type, value):
+        return {"ValueTypeId": value_type.value, "Value": value}
+
+class FakeCoordinator:
+    def __init__(self, hass, update_interval, taphome_api_service, core_id):
+        self.hass = hass
+        self.taphome_api_service = taphome_api_service
+        self.core_id = core_id
+        self.update_interval = update_interval
+        self._devices = {}
+        self.last_update_success = False
+
+    async def async_refresh(self):
+        devices = await self.taphome_api_service.async_discovery_devices()
+        for dev in devices:
+            self._devices[dev.id] = {"device": dev, "values": None}
+        values = await self.taphome_api_service.async_get_all_devices_values()
+        for item in values["devices"]:
+            self._devices[item["deviceId"]]["values"] = item["values"]
+        self.last_update_success = True
+
+    def ensure_can_be_register_entity(self, device_id):
+        return True
+
+    def register_entity(self, device_id, device_change_handler, state_change_handler):
+        device_change_handler()
+        state_change_handler()
+
+    def get_device(self, device_id):
+        return self._devices[device_id]["device"]
+
+    def get_state(self, device_id, state_type):
+        values = self._devices[device_id]["values"]
+        if values is None:
+            return None
+        return state_type(values)
+
+@pytest.fixture(autouse=True)
+def patch_integration(monkeypatch):
+    monkeypatch.setattr(taphome, "TapHomeApiService", FakeTapHomeApiService)
+    monkeypatch.setattr(taphome.TapHomeHttpClientFactory, "create", lambda self, api_url, token: None)
+    monkeypatch.setattr(taphome, "TapHomeDataUpdateCoordinator", FakeCoordinator)
+    monkeypatch.setattr(taphome, "load_platform", lambda *args, **kwargs: None)
+    monkeypatch.setattr(taphome, "async_register_webhook", lambda *args, **kwargs: None)
+
+class FakeHass:
+    def __init__(self):
+        self.data = {}
+
+@pytest.mark.asyncio
+async def test_setup_and_switch_update():
+    hass = FakeHass()
+    config = {
+        taphome.const.TAPHOME_PLATFORM: {
+            taphome.const.CONF_CORES: [
+                {
+                    taphome.const.CONF_TOKEN: "token",
+                    taphome.const.CONF_SWITCHES: [{"id": 1}],
+                }
+            ]
+        }
+    }
+    assert await taphome.async_setup(hass, config)
+
+    entities = []
+    def add_entities(new):
+        entities.extend(new)
+
+    import switch
+    await switch.setup_platform(hass, {}, add_entities)
+
+    assert len(entities) == 1
+    switch_entity = entities[0]
+    assert switch_entity.is_on
+    await switch_entity.async_turn_off()
+    assert not switch_entity.is_on

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,12 +13,12 @@ if homeassistant_spec is None or aiohttp_spec is None:
 
 from taphome_sdk import Device, SwitchStates, ValueType  # noqa: E402
 
-# load integration as custom_components.taphome
+# load integration as package "taphome" so relative imports work
 spec = importlib.util.spec_from_file_location(
-    "custom_components.taphome", "__init__.py"
+    "taphome", "__init__.py", submodule_search_locations=[str(ROOT)]
 )
 taphome = importlib.util.module_from_spec(spec)
-sys.modules["custom_components.taphome"] = taphome
+sys.modules["taphome"] = taphome
 spec.loader.exec_module(taphome)
 
 class FakeTapHomeApiService:


### PR DESCRIPTION
## Summary
- create tests for integration setup and state update
- mock TapHome API in tests
- run pytest in CI workflow

## Testing
- `ruff check .`
- `pytest -q` *(fails: 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68894817211483298d5c462e1419b275