### PR TITLE
Handle non-exposed devices

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import CONF_BINARY_SENSORS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .add_entry_request import add_taphome_entities
 from .const import TAPHOME_PLATFORM
 from .taphome_config_entry import (
     AddEntryRequest,
@@ -217,13 +218,14 @@ def setup_platform(
     _discovery_info=None,
 ) -> None:
     """Set up the binary sensor platform."""
-    add_entry_requests: list[AddEntryRequest[BinarySensorEntityConfig]] = hass.data[
-        TAPHOME_PLATFORM
-    ][CONF_BINARY_SENSORS]
-
     binary_sensors: list[BinarySensorEntity] = []
-    for config in add_entry_requests:
-        binary_sensors.extend(TapHomeBinarySensorFactory(config).create_entities())
+
+    add_taphome_entities(
+        hass,
+        binary_sensors.extend,
+        CONF_BINARY_SENSORS,
+        lambda config: TapHomeBinarySensorFactory(config).create_entities(),
+    )
 
     cores = {}
     for domain in hass.data[TAPHOME_PLATFORM]:

--- a/sensor.py
+++ b/sensor.py
@@ -33,7 +33,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import TAPHOME_PLATFORM
+from .add_entry_request import add_taphome_entities
 from .taphome_config_entry import AddEntryRequest, TapHomeEntityConfig
 from .taphome_entity import TapHomeEntity
 from .taphome_sdk import Device, DeviceState, ValueType
@@ -377,11 +377,4 @@ def setup_platform(
     _discovery_info=None,
 ) -> None:
     """Set up the sensor platform."""
-    add_entry_requests: list[AddEntryRequest] = hass.data[TAPHOME_PLATFORM][
-        CONF_SENSORS
-    ]
-
-    sensors: list[TapHomeSensor] = []
-    for config in add_entry_requests:
-        sensors.extend(create_entities(config))
-    add_entities(sensors)
+    add_taphome_entities(hass, add_entities, CONF_SENSORS, create_entities)


### PR DESCRIPTION
## Summary
- Ignore TapHome devices that aren't exposed in the API when setting up sensors and binary sensors
- Use shared helper to create entities and skip invalid devices

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68b977e463fc8329b71417639685e636